### PR TITLE
InkML file conversion feature

### DIFF
--- a/app/neural_network/inkml2img.py
+++ b/app/neural_network/inkml2img.py
@@ -1,12 +1,17 @@
 import numpy as np
-from skimage.draw import line
-from skimage.morphology import thin
 import matplotlib.pyplot as plt
 import xml.etree.ElementTree as ET
+from PIL import Image, ImageDraw
 
 
 def get_traces_data(inkml_file_abs_path, xmlns='{http://www.w3.org/2003/InkML}'):
-
+    """
+    Extracs and returns X Y coordinates from InkML file + ground truth formula in form of string.
+    :param inkml_file_abs_path: path to InkML file
+    :param xmlns: XML namespace
+    :return: traces_data - list of dictionaries with coordinates and labels
+    :return: formula - ground truth formula
+    """
     traces_data = []
 
     tree = ET.parse(inkml_file_abs_path)
@@ -16,17 +21,10 @@ def get_traces_data(inkml_file_abs_path, xmlns='{http://www.w3.org/2003/InkML}')
 
     'Stores traces_all with their corresponding id'
     'Remove 3rd coordinate - speed in m/s'
-    # traces_all = [{'id': trace_tag.get('id'),
-    #                'coords': [[round(float(axis_coord)) if float(axis_coord).is_integer() else round(float(axis_coord) * 10000)
-    #                            for axis_coord in coord[1:].split(' ')] if coord.startswith(' ')
-    #                           else [round(float(axis_coord)) if float(axis_coord).is_integer() else round(float(axis_coord) * 10000)
-    #                                 for axis_coord in coord.split(' ')]
-    #                           for coord in (trace_tag.text).replace('\n', '').split(',')]}
-    #               for trace_tag in root.findall(doc_namespace + 'trace')]
     traces_all = [{'id': trace_tag.get('id'),
-                    'coords': [[round(float(axis_coord) * 10000)
+                    'coords': [[round(float(axis_coord))
                                 for axis_coord in coord[1:].split(' ')[:2]] if coord.startswith(' ')
-                                else [round(float(axis_coord) * 10000)
+                                else [round(float(axis_coord))
                                     for axis_coord in coord.split(' ')[:2]]
                                 for coord in (trace_tag.text).replace('\n', '').split(',')]}
                     for trace_tag in root.findall(doc_namespace + 'trace')]
@@ -57,86 +55,82 @@ def get_traces_data(inkml_file_abs_path, xmlns='{http://www.w3.org/2003/InkML}')
 
     else:
         'Consider Validation data that has no labels'
+        'Our case - traces aren\'t grouped into traceGroups'
+        # for idx, trace in enumerate(traces_all):
+        #     traces_data.append({'trace_group': [trace['coords']]})
         [traces_data.append({'trace_group': [trace['coords']]})
          for trace in traces_all]
         # for idx, trace in enumerate(traces_all):
         #     traces_data.append({'label': str(idx), 'trace_group': [trace['coords']]})
 
-    return traces_data
+    'Extract the ground truth from normalizedLabel'
+    formula = None
+    annotations = root.findall(doc_namespace + 'annotation')
+    if annotations:
+        for annotation in annotations:
+            if annotation.get('type') == 'normalizedLabel':
+                formula = annotation.text
+
+    return traces_data, formula
 
 
-def convert_to_imgs(traces_data, box_size=int(100)):
+def inkml2img(inkml_file_abs_path, img_height=int(80), line_width=int(1), padding=int(0), color="black"):
+    """
+    Converts InkML file to an image with specified height and line width.
+    :param inkml_file_abs_path: path to InkML file
+    :param img_height: height of the output image (width is variable)
+    :param line_width: width of the lines in the image
+    :param padding: padding around the image
+    :return: img - PIL Image object
+    :return: latex - ground truth formula
+    """
+    traces_data, formula = get_traces_data(inkml_file_abs_path)
+    all_traces = []
+    [all_traces.append(trace_grp['trace_group']) for trace_grp in traces_data]
+    all_traces_collapsed = [trace for trace_group in all_traces for trace in trace_group]
 
-    patterns_enc = []
-    classes_rejected = []
+    # Compute min and max coordinates for all traces
+    min_x, min_y, max_x, max_y = get_min_coords(all_traces_collapsed)
 
-    for pattern in traces_data:
+    # Shift the trace group to align with (0, 0)
+    all_traces = [shift_trace_grp(trace, min_x=min_x, min_y=min_y) for trace in all_traces]
 
-        trace_group = pattern['trace_group']
+    # Interpolate the traces to have a height of 80 pixels
+    trace_height = max_y - min_y
+    trace_width = max_x - min_x
+    all_traces = [interpolate(trace_group, trace_grp_height=trace_height, trace_grp_width=trace_width, box_size=img_height - 1 - (padding*2)) for trace_group in all_traces]
 
-        'mid coords needed to shift the pattern'
-        min_x, min_y, max_x, max_y = get_min_coords(trace_group)
+    # Compute the new width after interpolation
+    new_width = max([max([coord[0] for coord in trace]) for trace_group in all_traces for trace in trace_group]) + 1 + (padding*2)
+    new_height = img_height  # Fixed height
 
-        'traceGroup dimensions'
-        trace_grp_height, trace_grp_width = max_y - min_y, max_x - min_x
+    # Create a blank white image
+    img = Image.new("RGB", (new_width, new_height), "white")
+    draw = ImageDraw.Draw(img)
 
-        'shift pattern to its relative position'
-        shifted_trace_grp = shift_trace_grp(
-            trace_group, min_x=min_x, min_y=min_y)
-
-        'Interpolates a pattern so that it fits into a box with specified size'
-        'method: LINEAR INTERPOLATION'
-        try:
-            interpolated_trace_grp = interpolate(shifted_trace_grp,
-                                                 trace_grp_height=trace_grp_height, trace_grp_width=trace_grp_width, box_size=box_size - 1)
-        except Exception as e:
-            print(e)
-            print('This data is corrupted - skipping.')
-            classes_rejected.append(pattern.get('label'))
-
-            continue
-
-        'Get min, max coords once again in order to center scaled patter inside the box'
-        min_x, min_y, max_x, max_y = get_min_coords(interpolated_trace_grp)
-
-        centered_trace_grp = center_pattern(
-            interpolated_trace_grp, max_x=max_x, max_y=max_y, box_size=box_size)
-
-        'Center scaled pattern so it fits a box with specified size'
-        pattern_drawn = draw_pattern(centered_trace_grp, box_size=box_size)
-        # Make sure that patterns are thinned (1 pixel thick)
-        pat_thinned = 1.0 - thin(1.0 - np.asarray(pattern_drawn))
-        plt.imshow(pat_thinned, cmap='gray')
-        plt.show()
-        pattern_enc = dict(
-            {'features': pat_thinned, 'label': pattern.get('label')})
-
-        # Filter classes that belong to categories selected by the user
-#             if pattern_enc.get('label') in self.classes:
-
-        patterns_enc.append(pattern_enc)
-
-    return patterns_enc, classes_rejected
+    # Draw the traces on the image
+    for trace_group in all_traces:
+        for trace in trace_group:
+            if len(trace) == 1:
+                # Draw a single point
+                x, y = trace[0]
+                draw.point((x+padding, y+padding), fill=color, size=line_width)
+            else:
+                # Draw lines connecting the points
+                for i in range(len(trace) - 1):
+                    x1, y1 = trace[i]
+                    x2, y2 = trace[i + 1]
+                    draw.line((x1+padding, y1+padding, x2+padding, y2+padding), fill=color, width=line_width)
+    return img, formula
 
 
 def get_min_coords(trace_group):
+    min_x_coords = min([coord[0] for trace in trace_group for coord in trace])
+    min_y_coords = min([coord[1] for trace in trace_group for coord in trace])
+    max_x_coords = max([coord[0] for trace in trace_group for coord in trace])
+    max_y_coords = max([coord[1] for trace in trace_group for coord in trace])
 
-    min_x_coords = []
-    min_y_coords = []
-    max_x_coords = []
-    max_y_coords = []
-
-    for trace in trace_group:
-
-        x_coords = [coord[0] for coord in trace]
-        y_coords = [coord[1] for coord in trace]
-
-        min_x_coords.append(min(x_coords))
-        min_y_coords.append(min(y_coords))
-        max_x_coords.append(max(x_coords))
-        max_y_coords.append(max(y_coords))
-
-    return min(min_x_coords), min(min_y_coords), max(max_x_coords), max(max_y_coords)
+    return min_x_coords, min_y_coords, max_x_coords, max_y_coords
 
 
 def shift_trace_grp(trace_group, min_x, min_y):
@@ -161,17 +155,8 @@ def interpolate(trace_group, trace_grp_height, trace_grp_width, box_size):
     if trace_grp_width == 0:
         trace_grp_width += 1
 
-    '' 'KEEP original size ratio' ''
-    trace_grp_ratio = (trace_grp_width) / (trace_grp_height)
-
-    scale_factor = 1.0
-    '' 'Set \"rescale coefficient\" magnitude' ''
-    if trace_grp_ratio < 1.0:
-
-        scale_factor = (box_size / trace_grp_height)
-    else:
-
-        scale_factor = (box_size / trace_grp_width)
+    'Scale for new heigh = box_size'
+    scale_factor = box_size / trace_grp_height
 
     for trace in trace_group:
         'coordintes convertion to int type necessary'
@@ -183,85 +168,9 @@ def interpolate(trace_group, trace_grp_height, trace_grp_width, box_size):
     return interpolated_trace_grp
 
 
-def get_min_coords(trace_group):
-
-    min_x_coords = []
-    min_y_coords = []
-    max_x_coords = []
-    max_y_coords = []
-
-    for trace in trace_group:
-
-        x_coords = [coord[0] for coord in trace]
-        y_coords = [coord[1] for coord in trace]
-
-        min_x_coords.append(min(x_coords))
-        min_y_coords.append(min(y_coords))
-        max_x_coords.append(max(x_coords))
-        max_y_coords.append(max(y_coords))
-
-    return min(min_x_coords), min(min_y_coords), max(max_x_coords), max(max_y_coords)
-
-
-def center_pattern(trace_group, max_x, max_y, box_size):
-
-    x_margin = int((box_size - max_x) / 2)
-    y_margin = int((box_size - max_y) / 2)
-
-    return shift_trace_grp(trace_group, min_x=-x_margin, min_y=-y_margin)
-
-
-def draw_pattern(trace_group, box_size):
-
-    pattern_drawn = np.ones(shape=(box_size, box_size), dtype=np.float32)
-    for trace in trace_group:
-
-        ' SINGLE POINT TO DRAW '
-        if len(trace) == 1:
-            x_coord = trace[0][0]
-            y_coord = trace[0][1]
-            pattern_drawn[y_coord, x_coord] = 0.0
-
-        else:
-            ' TRACE HAS MORE THAN 1 POINT '
-
-            'Iterate through list of traces endpoints'
-            for pt_idx in range(len(trace) - 1):
-                print(pt_idx, trace[pt_idx])
-
-                'Indices of pixels that belong to the line. May be used to directly index into an array'
-                pattern_drawn[line(r0=int(trace[pt_idx][1]), c0=int(trace[pt_idx][0]),
-                                   r1=int(trace[pt_idx + 1][1]), c1=int(trace[pt_idx + 1][0]))] = 0
-
-    return pattern_drawn
-
-
-def inkml2img(input_path, output_path, color='black'):
-    traces = get_traces_data(input_path)
-    # print(traces)
-    # print(get_min_coords(traces[0]['trace_group']))
-    for elem in traces:
-        ls = elem['trace_group']
-        for subls in ls:
-            data = np.array(subls)
-            x, y = zip(*data)
-            plt.plot(x, y, linewidth=2, c=color)
-            # plt.scatter(x, y, s=5, c=color)
- 
-    plt.gca().invert_yaxis()
-    plt.gca().set_aspect('equal', adjustable='box')
-    plt.gca().get_xaxis().set_visible(False)
-    plt.gca().get_yaxis().set_visible(False)
-    plt.gca().spines['top'].set_visible(False)
-    plt.gca().spines['right'].set_visible(False)
-    plt.gca().spines['bottom'].set_visible(False)
-    plt.gca().spines['left'].set_visible(False)
-    plt.savefig(output_path, bbox_inches='tight', dpi=100)
-    plt.gcf().clear()
-
-
 if __name__ == "__main__":
     import sys
     input_inkml = sys.argv[1]
-    output_path = sys.argv[2]
-    inkml2img(input_inkml, output_path)     # , color='#284054'
+    img = inkml2img(input_inkml, img_height=80, line_width=1, padding=2, color='#284054')
+    img.show()
+    print(img.size)

--- a/app/neural_network/inkml2img.py
+++ b/app/neural_network/inkml2img.py
@@ -83,7 +83,7 @@ def inkml2img(inkml_file_abs_path, img_height=int(80), line_width=int(1), paddin
     :param img_height: height of the output image (width is variable)
     :param line_width: width of the lines in the image
     :param padding: padding around the image
-    :return: img - PIL Image object
+    :return: image in form of np.array for easy handling (converted from  PIL Image object)
     :return: latex - ground truth formula
     """
     traces_data, formula = get_traces_data(inkml_file_abs_path)
@@ -123,7 +123,7 @@ def inkml2img(inkml_file_abs_path, img_height=int(80), line_width=int(1), paddin
                     x1, y1 = trace[i]
                     x2, y2 = trace[i + 1]
                     draw.line((x1+padding, y1+padding, x2+padding, y2+padding), fill=color, width=line_width)
-    return img, formula
+    return np.array(img), formula
 
 
 def get_min_coords(trace_group):

--- a/app/neural_network/inkml2img.py
+++ b/app/neural_network/inkml2img.py
@@ -1,0 +1,267 @@
+import numpy as np
+from skimage.draw import line
+from skimage.morphology import thin
+import matplotlib.pyplot as plt
+import xml.etree.ElementTree as ET
+
+
+def get_traces_data(inkml_file_abs_path, xmlns='{http://www.w3.org/2003/InkML}'):
+
+    traces_data = []
+
+    tree = ET.parse(inkml_file_abs_path)
+    root = tree.getroot()
+    # doc_namespace = "{http://www.w3.org/2003/InkML}"
+    doc_namespace = xmlns
+
+    'Stores traces_all with their corresponding id'
+    'Remove 3rd coordinate - speed in m/s'
+    # traces_all = [{'id': trace_tag.get('id'),
+    #                'coords': [[round(float(axis_coord)) if float(axis_coord).is_integer() else round(float(axis_coord) * 10000)
+    #                            for axis_coord in coord[1:].split(' ')] if coord.startswith(' ')
+    #                           else [round(float(axis_coord)) if float(axis_coord).is_integer() else round(float(axis_coord) * 10000)
+    #                                 for axis_coord in coord.split(' ')]
+    #                           for coord in (trace_tag.text).replace('\n', '').split(',')]}
+    #               for trace_tag in root.findall(doc_namespace + 'trace')]
+    traces_all = [{'id': trace_tag.get('id'),
+                    'coords': [[round(float(axis_coord) * 10000)
+                                for axis_coord in coord[1:].split(' ')[:2]] if coord.startswith(' ')
+                                else [round(float(axis_coord) * 10000)
+                                    for axis_coord in coord.split(' ')[:2]]
+                                for coord in (trace_tag.text).replace('\n', '').split(',')]}
+                    for trace_tag in root.findall(doc_namespace + 'trace')]
+
+    'Sort traces_all list by id to make searching for references faster'
+    traces_all.sort(key=lambda trace_dict: int(trace_dict['id']))
+
+    'Always 1st traceGroup is a redundant wrapper'
+    traceGroupWrapper = root.find(doc_namespace + 'traceGroup')
+
+    if traceGroupWrapper is not None:
+        for traceGroup in traceGroupWrapper.findall(doc_namespace + 'traceGroup'):
+
+            label = traceGroup.find(doc_namespace + 'annotation').text
+
+            'traces of the current traceGroup'
+            traces_curr = []
+            for traceView in traceGroup.findall(doc_namespace + 'traceView'):
+
+                'Id reference to specific trace tag corresponding to currently considered label'
+                traceDataRef = int(traceView.get('traceDataRef'))
+
+                'Each trace is represented by a list of coordinates to connect'
+                single_trace = traces_all[traceDataRef]['coords']
+                traces_curr.append(single_trace)
+
+            traces_data.append({'label': label, 'trace_group': traces_curr})
+
+    else:
+        'Consider Validation data that has no labels'
+        [traces_data.append({'trace_group': [trace['coords']]})
+         for trace in traces_all]
+        # for idx, trace in enumerate(traces_all):
+        #     traces_data.append({'label': str(idx), 'trace_group': [trace['coords']]})
+
+    return traces_data
+
+
+def convert_to_imgs(traces_data, box_size=int(100)):
+
+    patterns_enc = []
+    classes_rejected = []
+
+    for pattern in traces_data:
+
+        trace_group = pattern['trace_group']
+
+        'mid coords needed to shift the pattern'
+        min_x, min_y, max_x, max_y = get_min_coords(trace_group)
+
+        'traceGroup dimensions'
+        trace_grp_height, trace_grp_width = max_y - min_y, max_x - min_x
+
+        'shift pattern to its relative position'
+        shifted_trace_grp = shift_trace_grp(
+            trace_group, min_x=min_x, min_y=min_y)
+
+        'Interpolates a pattern so that it fits into a box with specified size'
+        'method: LINEAR INTERPOLATION'
+        try:
+            interpolated_trace_grp = interpolate(shifted_trace_grp,
+                                                 trace_grp_height=trace_grp_height, trace_grp_width=trace_grp_width, box_size=box_size - 1)
+        except Exception as e:
+            print(e)
+            print('This data is corrupted - skipping.')
+            classes_rejected.append(pattern.get('label'))
+
+            continue
+
+        'Get min, max coords once again in order to center scaled patter inside the box'
+        min_x, min_y, max_x, max_y = get_min_coords(interpolated_trace_grp)
+
+        centered_trace_grp = center_pattern(
+            interpolated_trace_grp, max_x=max_x, max_y=max_y, box_size=box_size)
+
+        'Center scaled pattern so it fits a box with specified size'
+        pattern_drawn = draw_pattern(centered_trace_grp, box_size=box_size)
+        # Make sure that patterns are thinned (1 pixel thick)
+        pat_thinned = 1.0 - thin(1.0 - np.asarray(pattern_drawn))
+        plt.imshow(pat_thinned, cmap='gray')
+        plt.show()
+        pattern_enc = dict(
+            {'features': pat_thinned, 'label': pattern.get('label')})
+
+        # Filter classes that belong to categories selected by the user
+#             if pattern_enc.get('label') in self.classes:
+
+        patterns_enc.append(pattern_enc)
+
+    return patterns_enc, classes_rejected
+
+
+def get_min_coords(trace_group):
+
+    min_x_coords = []
+    min_y_coords = []
+    max_x_coords = []
+    max_y_coords = []
+
+    for trace in trace_group:
+
+        x_coords = [coord[0] for coord in trace]
+        y_coords = [coord[1] for coord in trace]
+
+        min_x_coords.append(min(x_coords))
+        min_y_coords.append(min(y_coords))
+        max_x_coords.append(max(x_coords))
+        max_y_coords.append(max(y_coords))
+
+    return min(min_x_coords), min(min_y_coords), max(max_x_coords), max(max_y_coords)
+
+
+def shift_trace_grp(trace_group, min_x, min_y):
+
+    shifted_trace_grp = []
+
+    for trace in trace_group:
+        shifted_trace = [[coord[0] - min_x, coord[1] - min_y]
+                         for coord in trace]
+
+        shifted_trace_grp.append(shifted_trace)
+
+    return shifted_trace_grp
+
+
+def interpolate(trace_group, trace_grp_height, trace_grp_width, box_size):
+
+    interpolated_trace_grp = []
+
+    if trace_grp_height == 0:
+        trace_grp_height += 1
+    if trace_grp_width == 0:
+        trace_grp_width += 1
+
+    '' 'KEEP original size ratio' ''
+    trace_grp_ratio = (trace_grp_width) / (trace_grp_height)
+
+    scale_factor = 1.0
+    '' 'Set \"rescale coefficient\" magnitude' ''
+    if trace_grp_ratio < 1.0:
+
+        scale_factor = (box_size / trace_grp_height)
+    else:
+
+        scale_factor = (box_size / trace_grp_width)
+
+    for trace in trace_group:
+        'coordintes convertion to int type necessary'
+        interpolated_trace = [
+            [round(coord[0] * scale_factor), round(coord[1] * scale_factor)] for coord in trace]
+
+        interpolated_trace_grp.append(interpolated_trace)
+
+    return interpolated_trace_grp
+
+
+def get_min_coords(trace_group):
+
+    min_x_coords = []
+    min_y_coords = []
+    max_x_coords = []
+    max_y_coords = []
+
+    for trace in trace_group:
+
+        x_coords = [coord[0] for coord in trace]
+        y_coords = [coord[1] for coord in trace]
+
+        min_x_coords.append(min(x_coords))
+        min_y_coords.append(min(y_coords))
+        max_x_coords.append(max(x_coords))
+        max_y_coords.append(max(y_coords))
+
+    return min(min_x_coords), min(min_y_coords), max(max_x_coords), max(max_y_coords)
+
+
+def center_pattern(trace_group, max_x, max_y, box_size):
+
+    x_margin = int((box_size - max_x) / 2)
+    y_margin = int((box_size - max_y) / 2)
+
+    return shift_trace_grp(trace_group, min_x=-x_margin, min_y=-y_margin)
+
+
+def draw_pattern(trace_group, box_size):
+
+    pattern_drawn = np.ones(shape=(box_size, box_size), dtype=np.float32)
+    for trace in trace_group:
+
+        ' SINGLE POINT TO DRAW '
+        if len(trace) == 1:
+            x_coord = trace[0][0]
+            y_coord = trace[0][1]
+            pattern_drawn[y_coord, x_coord] = 0.0
+
+        else:
+            ' TRACE HAS MORE THAN 1 POINT '
+
+            'Iterate through list of traces endpoints'
+            for pt_idx in range(len(trace) - 1):
+                print(pt_idx, trace[pt_idx])
+
+                'Indices of pixels that belong to the line. May be used to directly index into an array'
+                pattern_drawn[line(r0=int(trace[pt_idx][1]), c0=int(trace[pt_idx][0]),
+                                   r1=int(trace[pt_idx + 1][1]), c1=int(trace[pt_idx + 1][0]))] = 0
+
+    return pattern_drawn
+
+
+def inkml2img(input_path, output_path, color='black'):
+    traces = get_traces_data(input_path)
+    # print(traces)
+    # print(get_min_coords(traces[0]['trace_group']))
+    for elem in traces:
+        ls = elem['trace_group']
+        for subls in ls:
+            data = np.array(subls)
+            x, y = zip(*data)
+            plt.plot(x, y, linewidth=2, c=color)
+            # plt.scatter(x, y, s=5, c=color)
+ 
+    plt.gca().invert_yaxis()
+    plt.gca().set_aspect('equal', adjustable='box')
+    plt.gca().get_xaxis().set_visible(False)
+    plt.gca().get_yaxis().set_visible(False)
+    plt.gca().spines['top'].set_visible(False)
+    plt.gca().spines['right'].set_visible(False)
+    plt.gca().spines['bottom'].set_visible(False)
+    plt.gca().spines['left'].set_visible(False)
+    plt.savefig(output_path, bbox_inches='tight', dpi=100)
+    plt.gcf().clear()
+
+
+if __name__ == "__main__":
+    import sys
+    input_inkml = sys.argv[1]
+    output_path = sys.argv[2]
+    inkml2img(input_inkml, output_path)     # , color='#284054'

--- a/app/neural_network/prepare_dataset.py
+++ b/app/neural_network/prepare_dataset.py
@@ -5,7 +5,7 @@ from tqdm import tqdm
 import argparse
 from skimage import io
 import six
-import inkml2img
+from .inkml2img import inkml2img
 
 
 def prepare_dataset(input_dir, output_dir, train_ratio=0.8, val_ratio=0.1, test_ratio=0.1, limit=None):
@@ -57,7 +57,7 @@ def prepare_dataset(input_dir, output_dir, train_ratio=0.8, val_ratio=0.1, test_
 
             inkml_path = os.path.join(input_images_dir, inkml_file)
             # Načtení obrázku z INKML
-            image, formula = inkml2img.inkml2img(inkml_path, img_height=80, line_width=1, padding=0, color="black")
+            image, formula = inkml2img(inkml_path, img_height=80, line_width=1, padding=0, color="black")
 
             # Uložení obrázku jako PNG
             output_image_path = os.path.join(input_images_dir, image_name)

--- a/app/neural_network/prepare_dataset.py
+++ b/app/neural_network/prepare_dataset.py
@@ -3,6 +3,8 @@ import shutil
 import random
 from tqdm import tqdm
 import argparse
+from skimage import io
+import six
 
 
 def prepare_dataset(input_dir, output_dir, train_ratio=0.8, val_ratio=0.1, test_ratio=0.1, limit=None):


### PR DESCRIPTION
Added InkML file support into prepare_dataset.py based on [https://github.com/RobinXL/inkml2img](https://github.com/RobinXL/inkml2img). Library __inkml2img.py__ contains necessary functions for loading InkML files, extracting the stroke coordinates and the latex ground truth and finally generating image based on the coordinates, with options of image height, stroke width, padding and color.  __prepare_dataset.py__ now handles files with .inkml suffix correctly, generates .png files and appends __train_labels.txt__ accordigly. Possibility to add noise and other augmentation methods onto the sythetic images in upcoming versions. 

![00bc1c89dff0672e](https://github.com/user-attachments/assets/9a458d71-d3b5-4eac-ad0b-9ed9d7070f95)
(example of synthetic image with 80px height, 2px stroke width and 2px padding)